### PR TITLE
Bug 707105: Avoid special handling for pattern transparency when the pattern is solid black

### DIFF
--- a/pcl/pcl/rtraster.c
+++ b/pcl/pcl/rtraster.c
@@ -1187,6 +1187,9 @@ pcl_start_raster(uint src_width, uint src_height, pcl_state_t * pcs)
     pcl_cs_indexed_t *pindexed = ppalet->pindexed;
     pcl_encoding_type_t penc = pcl_cs_indexed_get_encoding(pindexed);
     pcl_seed_row_t *pseed_rows = 0;
+    int pattern_could_be_transparent =
+            pcs->pattern_transparent &&
+            pcs->pattern_type != pcl_pattern_solid_frgrnd;
 
     /* there can only be one raster object present at a time */
     if (prast != 0)
@@ -1199,7 +1202,7 @@ pcl_start_raster(uint src_width, uint src_height, pcl_state_t * pcs)
 
     prast->pmem = pcs->memory;
 
-    if (pcs->source_transparent || pcs->pattern_transparent)
+    if (pcs->source_transparent || pattern_could_be_transparent)
         prast->transparent = true;
     else
         prast->transparent = false;
@@ -1306,7 +1309,7 @@ pcl_start_raster(uint src_width, uint src_height, pcl_state_t * pcs)
 
     /* see if a mask is required */
     if (!pcs->source_transparent &&
-        pcs->pattern_transparent &&
+        pattern_could_be_transparent &&
         (!prast->indexed ||
          (prast->wht_indx < (1 << prast->nplanes * prast->bits_per_plane)))) {
 


### PR DESCRIPTION
This fixes https://bugs.ghostscript.com/show_bug.cgi?id=707105
I have confirmed that the test files from the bug ticket work fine. I'm not sure whether there is an automated regression test suite, therefore, I did not do further regression testing yet.

When encountering transparency while printing raster data, the PCL code has to generate masks. This works when rendered as a bitmap but can lead to problems in the pdfwrite device. As long as the used pattern does not contain transparent pixels, there is no need to generate transparency masks, regardless of the value of pattern_transparency. This way, the result will be created correctly even with pdfwrite.