### PR TITLE
base: divide_count is mean to be a int, not bool

### DIFF
--- a/base/gxshade4.h
+++ b/base/gxshade4.h
@@ -88,7 +88,7 @@ typedef struct wedge_vertex_list_elem_s wedge_vertex_list_elem_t;
 struct wedge_vertex_list_elem_s {
     gs_fixed_point p;
     int level;
-    bool divide_count;
+    int divide_count;
     wedge_vertex_list_elem_t *next, *prev;
 };
 typedef struct {


### PR DESCRIPTION
It is incremented/decremented and compared to values that are not boolean true/false or 0/1..
This is entering the realm of UB.